### PR TITLE
修正鉴权接口文档

### DIFF
--- a/docs/zh/doc/参考文档/接口文档/鉴权管理.md
+++ b/docs/zh/doc/参考文档/接口文档/鉴权管理.md
@@ -304,14 +304,13 @@ Header X-Polaris-Token: {访问凭据}
 请求示例：
 
 ```
-GET /core/v1/user/token?id=xxx&name=xxx
+GET /core/v1/user/token?id=xxx
 Header X-Polaris-Token: {访问凭据}
 ```
 
 | 参数名 | 类型   | 描述   | 是否必填 |
 |--------|--------|------|---------|
-| id     | string | 用户ID | 否       |
-| name   | string | 用户ID | 否       |
+| id     | string | 用户ID | 是       |
 
 响应示例：
 


### PR DESCRIPTION
查看用户token接口只需要id就够了

```
func (h *HTTPServer) GetUserToken(req *restful.Request, rsp *restful.Response) {
	handler := &httpcommon.Handler{req, rsp}
	queryParams := httpcommon.ParseQueryParams(req)

	user := &api.User{
		Id: utils.NewStringValue(queryParams["id"]),
	}

	handler.WriteHeaderAndProto(h.authServer.GetUserToken(handler.ParseHeaderContext(), user))
}
```