### PR TITLE
style: 调整博客导航按钮样式

### DIFF
--- a/assets/scss/_variables_project.scss
+++ b/assets/scss/_variables_project.scss
@@ -626,14 +626,16 @@ html,
   line-height: 1.5;
   border-radius: 0.25rem;
   transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+
+  &:hover,
+  &:focus {
+    background-color: rgb(179, 181, 183) !important;
+    color: #696868;
+    text-decoration: none;
+  }
 }
 
 .disable-click {
-  background-color: rgb(175, 176, 178) !important;
-  color: #848486;
-
-  &:hover,&:focus {
-    background-color: rgb(175, 176, 178) !important;
-    color: #848486;
-  }
+  display: none !important;
 }
+


### PR DESCRIPTION
重新调整了博客导航的按钮样式, 使其更加符合直觉:

- 首篇文章隐藏上一篇按钮:
![image](https://user-images.githubusercontent.com/70408571/202386337-4095a613-a6f1-470f-90c8-10b50fe406ee.png)
- 改变鼠标指针悬浮的样式:
![image](https://user-images.githubusercontent.com/70408571/202386542-03e17554-b9b2-4d9b-b670-e66ad60a11a8.png)
